### PR TITLE
Remove invalid keyword from cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,4 @@ license-file = "LICENSE"
 repository = "https://github.com/microsoft/rust_fallible_vec"
 readme = "README.md"
 categories = ["embedded", "memory-management", "no-std"]
-keywords = ["vec", "fallible", "collections", "panic safe"]
+keywords = ["vec", "fallible", "collections", "no_std"]


### PR DESCRIPTION
`crates.io` does not permit whitespace in keywords.