### PR TITLE
Move `try_collect` into its own trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "fallible_vec"
-version = "0.1.0"
+version = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fallible_vec"
 description = "Fallible allocation functions for the Rust standard library's `Vec` type."
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license-file = "LICENSE"
 repository = "https://github.com/microsoft/rust_fallible_vec"

--- a/src/collect.rs
+++ b/src/collect.rs
@@ -1,0 +1,57 @@
+use crate::FallibleVec;
+use alloc::{collections::TryReserveError, vec::Vec};
+use core::alloc::Allocator;
+
+/// Fallible allocations equivalents for [`Iterator::collect`].
+pub trait TryCollect<T> {
+    /// Attempts to collect items from an iterator into a vector with the provided
+    /// allocator.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #![feature(allocator_api)]
+    /// # #[macro_use] extern crate fallible_vec;
+    /// use fallible_vec::*;
+    /// use std::alloc::System;
+    ///
+    /// let doubled = [1, 2, 3, 4, 5].map(|i| i * 2);
+    /// let vec = doubled.try_collect_in(System)?;
+    /// assert_eq!(vec, [2, 4, 6, 8, 10]);
+    /// # Ok::<(), std::collections::TryReserveError>(())
+    /// ```
+    fn try_collect_in<A: Allocator>(self, alloc: A) -> Result<Vec<T, A>, TryReserveError>;
+
+    /// Attempts to collect items from an iterator into a vector.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #![feature(allocator_api)]
+    /// # #[macro_use] extern crate fallible_vec;
+    /// use fallible_vec::*;
+    ///
+    /// let doubled = [1, 2, 3, 4, 5].map(|i| i * 2);
+    /// let vec = doubled.try_collect()?;
+    /// assert_eq!(vec, [2, 4, 6, 8, 10]);
+    /// # Ok::<(), std::collections::TryReserveError>(())
+    /// ```
+    fn try_collect(self) -> Result<Vec<T>, TryReserveError>;
+}
+
+impl<T, I> TryCollect<T> for I
+where
+    I: IntoIterator<Item = T>,
+{
+    fn try_collect_in<A: Allocator>(self, alloc: A) -> Result<Vec<T, A>, TryReserveError> {
+        let mut vec = Vec::new_in(alloc);
+        vec.try_extend(self.into_iter())?;
+        Ok(vec)
+    }
+
+    fn try_collect(self) -> Result<Vec<T>, TryReserveError> {
+        let mut vec = Vec::new();
+        vec.try_extend(self.into_iter())?;
+        Ok(vec)
+    }
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -142,7 +142,7 @@ fn test_collect_after_iterator_clone() {
     let v = try_vec_in![0; 5 => Global].unwrap();
     let mut i = v.into_iter().map(|i| i + 1).peekable();
     i.peek();
-    let v = try_collect_in(i.clone(), Global).unwrap();
+    let v = i.clone().try_collect().unwrap();
     assert_eq!(v, [1, 1, 1, 1, 1]);
     assert!(v.len() <= v.capacity());
 }


### PR DESCRIPTION
This makes using `try_collect` and `try_collect_in` more ergonomic as they will appear as a method on any `IntoIterator` type.